### PR TITLE
Corrections to Detarioideae and Papilionoideae lists

### DIFF
--- a/taxonomy/detarioideae.md
+++ b/taxonomy/detarioideae.md
@@ -67,80 +67,79 @@ Please see the [Species List and Synonyms](https://hp-legume.gbif-staging.org/ta
 
 |Genus                  | Data Source   |
 | --------------------- |------------------------------|-----------------------|
-| Afzelia Sm.|[Legume Data Portal](/taxonomy/taxon/624953)|    [GBIF](https://www.gbif.org/species/1470349)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331326-2)| 
-| Amherstia Wall.|[Legume Data Portal](/taxonomy/taxon/633618)|    [GBIF](https://www.gbif.org/species/2968145)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21630-1)|  
-| Annea Mackinder & Wieringa|[Legume Data Portal](/taxonomy/taxon/970606)|    [GBIF](https://www.gbif.org/species/9816525)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77133630-1)| 
-| Anthonotha P.Beauv.|[Legume Data Portal](/taxonomy/taxon/641697)|    [GBIF](https://www.gbif.org/species/2976601)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30048105-2)|
-| Aphanocalyx Oliver|[Legume Data Portal](/taxonomy/taxon/643388)|    [GBIF](https://www.gbif.org/species/2954231)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21689-1)|  
-| Augouardia Pellegr.|[Legume Data Portal](/taxonomy/taxon/666241)|    [GBIF](https://www.gbif.org/species/2954104)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21755-1)|  
-| Baikiaea Benth.|[Legume Data Portal](/taxonomy/taxon/667863)|    [GBIF](https://www.gbif.org/species/2943819)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21767-1)|  
-| Barnebydendron J.H.Kirkbr.|[Legume Data Portal](/taxonomy/taxon/670310)|    [GBIF](https://www.gbif.org/species/7278343)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1012322-1)|  
-| Berlinia Sol. ex Hook. f.|[Legume Data Portal](/taxonomy/taxon/674950)|    [GBIF](https://www.gbif.org/species/4929826)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331396-2)| 
-| Bikinia Wieringa|[Legume Data Portal](/taxonomy/taxon/675892)|    [GBIF](https://www.gbif.org/species/2954690)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1011127-1)|  
-| Brachycylix (Harms) R.S.Cowan|[Legume Data Portal](/taxonomy/taxon/681246)|    [GBIF](https://www.gbif.org/species/2933017)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21841-1)|  
-| Brachystegia Benth.|[Legume Data Portal](/taxonomy/taxon/681394)|    [GBIF](https://www.gbif.org/species/2952646)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21846-1)|  
-| Brandzeia Baill.|[Legume Data Portal](/taxonomy/taxon/681906)|    [GBIF](https://www.gbif.org/species/2959233)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21852-1)|  
-| Brodriguesia R.S.Cowan|[Legume Data Portal](/taxonomy/taxon/683479)|    [GBIF](https://www.gbif.org/species/2968204)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:924901-1)|
-| Brownea Jacq.|[Legume Data Portal](/taxonomy/taxon/683839)|    [GBIF](https://www.gbif.org/species/2970433)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331429-2)| 
-| Browneopsis Huber|[Legume Data Portal](/taxonomy/taxon/683889)|    [GBIF](https://www.gbif.org/species/2944236)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:296080-2)| 
-| Colophospermum J.Léonard|[Legume Data Portal](/taxonomy/taxon/731424)|    [GBIF](https://www.gbif.org/species/2974566)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22064-1)|  
-| Copaifera L.|[Legume Data Portal](/taxonomy/taxon/735808)|    [GBIF](https://www.gbif.org/species/2978115)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331514-2)| 
-| Crudia Schreb.|[Legume Data Portal](/taxonomy/taxon/745047)|    [GBIF](https://www.gbif.org/species/2974579)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:327294-2)| 
-| Cryptosepalum Benth.|[Legume Data Portal](/taxonomy/taxon/746504)|    [GBIF](https://www.gbif.org/species/2956479)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22142-1)|  
-| Cynometra L.|[Legume Data Portal](/taxonomy/taxon/752227)|    [GBIF](https://www.gbif.org/species/2966806)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22178-1)|  
-| Daniellia Benn.|[Legume Data Portal](/taxonomy/taxon/756752)|    [GBIF](https://www.gbif.org/species/2948719)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22208-1)|  
-| Detarium Juss.|[Legume Data Portal](/taxonomy/taxon/763143)|    [GBIF](https://www.gbif.org/species/2961173)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22234-1)|  
-| Dicymbe Spruce ex Benth. & Hook.f.|[Legume Data Portal](/taxonomy/taxon/767070)|    [GBIF](https://www.gbif.org/species/4929814)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22253-1)|  
-| Didelotia Baill.|[Legume Data Portal](/taxonomy/taxon/767109)|    [GBIF](https://www.gbif.org/species/2965869)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22255-1)|  
-| Ecuadendron D.A.Neill|[Legume Data Portal](/taxonomy/taxon/784507)|    [GBIF](https://www.gbif.org/species/2959137)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1001401-1)|  
-| Endertia Steenis & de Wit|[Legume Data Portal](/taxonomy/taxon/788792)|    [GBIF](https://www.gbif.org/species/2940358)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22360-1)|  
-| Englerodendron Harms|[Legume Data Portal](/taxonomy/taxon/789244)|    [GBIF](https://www.gbif.org/species/2970576)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22367-1)|  
-| Eperua Aubl.|[Legume Data Portal](/taxonomy/taxon/789844)|    [GBIF](https://www.gbif.org/species/2943504)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22371-1)|  
-| Eurypetalum Harms|[Legume Data Portal](/taxonomy/taxon/805216)|    [GBIF](https://www.gbif.org/species/8373292)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22406-1)|  
-| Gabonius Mackinder & Wieringa|[Legume Data Portal](/taxonomy/taxon/995876)|    [GBIF](https://www.gbif.org/species/9681719)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77133635-1)| 
-| Gilbertiodendron J.Léonard|[Legume Data Portal](/taxonomy/taxon/825237)|    [GBIF](https://www.gbif.org/species/2941642)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22485-1)|  
-| Gilletiodendron Vermoesen|[Legume Data Portal](/taxonomy/taxon/826004)|    [GBIF](https://www.gbif.org/species/2944302)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22486-1)|  
-| Goniorrhachis Taub.|[Legume Data Portal](/taxonomy/taxon/829617)|    [GBIF](https://www.gbif.org/species/2944249)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:295719-2)| 
-| Guibourtia Benn.|[Legume Data Portal](/taxonomy/taxon/834802)|    [GBIF](https://www.gbif.org/species/2964774)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22530-1)|  
-| Hardwickia Roxb.|[Legume Data Portal](/taxonomy/taxon/839537)|    [GBIF](https://www.gbif.org/species/2946903)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22557-1)|  
-| Heterostemon Desf.|[Legume Data Portal](/taxonomy/taxon/848554)|    [GBIF](https://www.gbif.org/species/2943910)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22595-1)|  
-| Humboldtia Vahl|[Legume Data Portal](/taxonomy/taxon/607458)|    [GBIF](https://www.gbif.org/species/2962724)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331664-2)| 
-| Hylodendron Taub.|[Legume Data Portal](/taxonomy/taxon/856882)|    [GBIF](https://www.gbif.org/species/2952761)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22634-1)|  
-| Hymenaea L.|[Legume Data Portal](/taxonomy/taxon/857026)|    [GBIF](https://www.gbif.org/species/2950720)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22635-1)|  
-| Hymenostegia Harms|[Legume Data Portal](/taxonomy/taxon/857347)|    [GBIF](https://www.gbif.org/species/2963360)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22642-1)|  
-| Icuria Wieringa|[Legume Data Portal](/taxonomy/taxon/860251)|    [GBIF](https://www.gbif.org/species/2945449)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1011139-1)|  
-| Intsia Thouars|[Legume Data Portal](/taxonomy/taxon/865920)|    [GBIF](https://www.gbif.org/species/2963210)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22666-1)|  
-| Isoberlinia Craib & Stapf|[Legume Data Portal](/taxonomy/taxon/867187)|    [GBIF](https://www.gbif.org/species/8108120)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22670-1)|  
-| Julbernardia Pellegr.|[Legume Data Portal](/taxonomy/taxon/331522)|    [GBIF](https://www.gbif.org/species/2981743)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22686-1)| 
-| Lebruniodendron J.Léonard|[Legume Data Portal](/taxonomy/taxon/351173)|    [GBIF](https://www.gbif.org/species/2983908)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22753-1)|  
-| Leonardoxa Aubrév.|[Legume Data Portal](/taxonomy/taxon/345888)|    [GBIF](https://www.gbif.org/species/2947375)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22765-1)|  
-| Leucostegane Prain|[Legume Data Portal](/taxonomy/taxon/351287)|    [GBIF](https://www.gbif.org/species/2952637)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22790-1)|  
-| Librevillea Hoyle|[Legume Data Portal](/taxonomy/taxon/351334)|    [GBIF](https://www.gbif.org/species/2941197)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22793-1)|  
-| Loesenera Harms|[Legume Data Portal](/taxonomy/taxon/346457)|    [GBIF](https://www.gbif.org/species/2944255)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22809-1)|  
-| Lysidice Hance|[Legume Data Portal](/taxonomy/taxon/346717)|    [GBIF](https://www.gbif.org/species/2958145)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22847-1)|  
-| Macrolobium Schreb.|[Legume Data Portal](/taxonomy/taxon/366400)|    [GBIF](https://www.gbif.org/species/7743878)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331742-2)| 
-| Michelsonia Hauman|[Legume Data Portal](/taxonomy/taxon/367964)|    [GBIF](https://www.gbif.org/species/2945463)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22931-1)|  
-| Micklethwaitia G.P.Lewis & Schrire|[Legume Data Portal](/taxonomy/taxon/376781)|    [GBIF](https://www.gbif.org/species/7301240)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:60435882-2)| 
-| Microberlinia A.Chev.|[Legume Data Portal](/taxonomy/taxon/367970)|    [GBIF](https://www.gbif.org/species/2941146)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22934-1)| 
-| Neoapaloxylon Rauschert|[Legume Data Portal](/taxonomy/taxon/383941)|    [GBIF](https://www.gbif.org/species/2944228)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:893558-1)| 
-| Neochevalierodendron J.Léonard|[Legume Data Portal](/taxonomy/taxon/383910)|    [GBIF](https://www.gbif.org/species/2975541)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23009-1)|  
-| Normandiodendron J.Léonard|[Legume Data Portal](/taxonomy/taxon/383480)|    [GBIF](https://www.gbif.org/species/7302225)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:974656-1)| 
-| Oddoniodendron De Wild.|[Legume Data Portal](/taxonomy/taxon/386693)|    [GBIF](https://www.gbif.org/species/2959958)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23058-1)|  
-| Paloue Aubl.|[Legume Data Portal](/taxonomy/taxon/531743)|    [GBIF](https://www.gbif.org/species/2958895)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30099319-2)| 
-| Paramacrolobium J.Léonard|[Legume Data Portal](/taxonomy/taxon/531894)|    [GBIF](https://www.gbif.org/species/2962898)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23144-1)|  
-| Peltogyne Vogel|[Legume Data Portal](/taxonomy/taxon/538385)|    [GBIF](https://www.gbif.org/species/2952686)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331837-2)| 
-| Plagiosiphon Harms|[Legume Data Portal](/taxonomy/taxon/539632)|    [GBIF](https://www.gbif.org/species/2961129)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23267-1)|  
-| Polystemonanthus Harms|[Legume Data Portal](/taxonomy/taxon/535816)|    [GBIF](https://www.gbif.org/species/2960420)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23320-1)| 
-| Prioria Griseb.|[Legume Data Portal](/taxonomy/taxon/536362)|    [GBIF](https://www.gbif.org/species/2947107)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23333-1)|  
-| Saraca L.|[Legume Data Portal](/taxonomy/taxon/592102)|    [GBIF](https://www.gbif.org/species/2372883)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23478-1)|  
-| Schotia Jacq.|[Legume Data Portal](/taxonomy/taxon/490365)|    [GBIF](https://www.gbif.org/species/2959237)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331941-2)| 
-| Scorodophloeus Harms|[Legume Data Portal](/taxonomy/taxon/591797)|    [GBIF](https://www.gbif.org/species/2952874)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23511-1)|  
-| Sindora Miq.|[Legume Data Portal](/taxonomy/taxon/591028)|    [GBIF](https://www.gbif.org/species/2943351)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23561-1)|  
-| Sindoropsis J.Léonard|[Legume Data Portal](/taxonomy/taxon/591062)|    [GBIF](https://www.gbif.org/species/2952642)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23562-1)| 
-| Stemonocoleus Harms|[Legume Data Portal](/taxonomy/taxon/597087)|    [GBIF](https://www.gbif.org/species/2951341)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23612-1)|  
-| Talbotiella Baker f.|[Legume Data Portal](/taxonomy/taxon/444684)|    [GBIF](https://www.gbif.org/species/2944645)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23657-1)|  
-| Tamarindus Tourn. ex L.|[Legume Data Portal](/taxonomy/taxon/444682)|    [GBIF](https://www.gbif.org/species/2975767)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23658-1)|  
-| Tessmannia Harms|[Legume Data Portal](/taxonomy/taxon/443659)|    [GBIF](https://www.gbif.org/species/2947679)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23679-1)|  
-| Tetraberlinia (Harms) Hauman|[Legume Data Portal](/taxonomy/taxon/443642)|    [GBIF](https://www.gbif.org/species/2952737)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23680-1)|  
-| Zenkerella Taub.|[Legume Data Portal](/taxonomy/taxon/470203)|    [GBIF](https://www.gbif.org/species/2439359)|[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23840-1)|  
-
+| Afzelia Sm.|  |[Legume Data Portal](/taxonomy/taxon/624953)|    [GBIF](https://www.gbif.org/species/1470349)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331326-2)| 
+| Amherstia Wall.|  |[Legume Data Portal](/taxonomy/taxon/633618)|    [GBIF](https://www.gbif.org/species/2968145)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21630-1)|  
+| Annea Mackinder & Wieringa| |[Legume Data Portal](/taxonomy/taxon/970606)|    [GBIF](https://www.gbif.org/species/9816525)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77133630-1)| 
+| Anthonotha P.Beauv.|  |[Legume Data Portal](/taxonomy/taxon/641697)|    [GBIF](https://www.gbif.org/species/2976601)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30048105-2)|
+| Aphanocalyx Oliver| |[Legume Data Portal](/taxonomy/taxon/643388)|    [GBIF](https://www.gbif.org/species/2954231)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21689-1)|  
+| Augouardia Pellegr.|  |[Legume Data Portal](/taxonomy/taxon/666241)|    [GBIF](https://www.gbif.org/species/2954104)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21755-1)|  
+| Baikiaea Benth.|  |[Legume Data Portal](/taxonomy/taxon/667863)|    [GBIF](https://www.gbif.org/species/2943819)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21767-1)|  
+| Barnebydendron J.H.Kirkbr.| |[Legume Data Portal](/taxonomy/taxon/670310)|    [GBIF](https://www.gbif.org/species/7278343)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1012322-1)|  
+| Berlinia Sol. ex Hook.f.|  |[Legume Data Portal](/taxonomy/taxon/674950)|    [GBIF](https://www.gbif.org/species/4929826)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331396-2)| 
+| Bikinia Wieringa| |[Legume Data Portal](/taxonomy/taxon/675892)|    [GBIF](https://www.gbif.org/species/2954690)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1011127-1)|  
+| Brachycylix (Harms) R.S.Cowan|  |[Legume Data Portal](/taxonomy/taxon/681246)|    [GBIF](https://www.gbif.org/species/2933017)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21841-1)|  
+| Brachystegia Benth.|  |[Legume Data Portal](/taxonomy/taxon/681394)|    [GBIF](https://www.gbif.org/species/2952646)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21846-1)|  
+| Brandzeia Baill.| |[Legume Data Portal](/taxonomy/taxon/681906)|    [GBIF](https://www.gbif.org/species/2959233)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21852-1)|  
+| Brodriguesia R.S.Cowan| |[Legume Data Portal](/taxonomy/taxon/683479)|    [GBIF](https://www.gbif.org/species/2968204)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:924901-1)|
+| Brownea Jacq.|  |[Legume Data Portal](/taxonomy/taxon/683839)|    [GBIF](https://www.gbif.org/species/2970433)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331429-2)| 
+| Browneopsis Huber|  |[Legume Data Portal](/taxonomy/taxon/683889)|    [GBIF](https://www.gbif.org/species/2944236)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:296080-2)| 
+| Colophospermum J.Léonard| |[Legume Data Portal](/taxonomy/taxon/731424)|    [GBIF](https://www.gbif.org/species/2974566)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22064-1)|  
+| Copaifera L.| |[Legume Data Portal](/taxonomy/taxon/735808)|    [GBIF](https://www.gbif.org/species/2978115)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331514-2)| 
+| Crudia Schreb.| |[Legume Data Portal](/taxonomy/taxon/745047)|    [GBIF](https://www.gbif.org/species/2974579)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:327294-2)| 
+| Cryptosepalum Benth.| |[Legume Data Portal](/taxonomy/taxon/746504)|    [GBIF](https://www.gbif.org/species/2956479)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22142-1)|  
+| Cynometra L.| |[Legume Data Portal](/taxonomy/taxon/752227)|    [GBIF](https://www.gbif.org/species/2966806)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22178-1)|  
+| Daniellia Benn.|  |[Legume Data Portal](/taxonomy/taxon/756752)|    [GBIF](https://www.gbif.org/species/2948719)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22208-1)|  
+| Detarium Juss.| |[Legume Data Portal](/taxonomy/taxon/763143)|    [GBIF](https://www.gbif.org/species/2961173)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22234-1)|  
+| Dicymbe Spruce ex Benth. & Hook.f.| |[Legume Data Portal](/taxonomy/taxon/767070)|    [GBIF](https://www.gbif.org/species/4929814)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22253-1)|  
+| Didelotia Baill.| |[Legume Data Portal](/taxonomy/taxon/767109)|    [GBIF](https://www.gbif.org/species/2965869)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22255-1)|  
+| Ecuadendron D.A.Neill|  |[Legume Data Portal](/taxonomy/taxon/784507)|    [GBIF](https://www.gbif.org/species/2959137)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1001401-1)|  
+| Endertia Steenis & de Wit|  |[Legume Data Portal](/taxonomy/taxon/788792)|    [GBIF](https://www.gbif.org/species/2940358)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22360-1)|  
+| Englerodendron Harms| |[Legume Data Portal](/taxonomy/taxon/789244)|    [GBIF](https://www.gbif.org/species/2970576)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22367-1)|  
+| Eperua Aubl.| |[Legume Data Portal](/taxonomy/taxon/789844)|    [GBIF](https://www.gbif.org/species/2943504)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22371-1)|  
+| Eurypetalum Harms|  |[Legume Data Portal](/taxonomy/taxon/805216)|    [GBIF](https://www.gbif.org/species/8373292)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22406-1)|  
+| Gabonius Mackinder & Wieringa|  |[Legume Data Portal](/taxonomy/taxon/995876)|    [GBIF](https://www.gbif.org/species/9681719)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77133635-1)| 
+| Gilbertiodendron J.Léonard| |[Legume Data Portal](/taxonomy/taxon/825237)|    [GBIF](https://www.gbif.org/species/2941642)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22485-1)|  
+| Gilletiodendron Vermoesen|  |[Legume Data Portal](/taxonomy/taxon/826004)|    [GBIF](https://www.gbif.org/species/2944302)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22486-1)|  
+| Goniorrhachis Taub.|  |[Legume Data Portal](/taxonomy/taxon/829617)|    [GBIF](https://www.gbif.org/species/2944249)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:295719-2)| 
+| Guibourtia Benn.| |[Legume Data Portal](/taxonomy/taxon/834802)|    [GBIF](https://www.gbif.org/species/2964774)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22530-1)|  
+| Hardwickia Roxb.| |[Legume Data Portal](/taxonomy/taxon/839537)|    [GBIF](https://www.gbif.org/species/2946903)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22557-1)|  
+| Heterostemon Desf.| |[Legume Data Portal](/taxonomy/taxon/848554)|    [GBIF](https://www.gbif.org/species/2943910)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22595-1)|  
+| Humboldtia Vahl|  |[Legume Data Portal](/taxonomy/taxon/607458)|    [GBIF](https://www.gbif.org/species/2962724)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331664-2)| 
+| Hylodendron Taub.|  |[Legume Data Portal](/taxonomy/taxon/856882)|    [GBIF](https://www.gbif.org/species/2952761)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22634-1)|  
+| Hymenaea L.|  |[Legume Data Portal](/taxonomy/taxon/857026)|    [GBIF](https://www.gbif.org/species/2950720)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22635-1)|  
+| Hymenostegia Harms|  |[Legume Data Portal](/taxonomy/taxon/857347)|    [GBIF](https://www.gbif.org/species/2963360)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22642-1)|  
+| Icuria Wieringa|  |[Legume Data Portal](/taxonomy/taxon/860251)|    [GBIF](https://www.gbif.org/species/2945449)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1011139-1)|  
+| Intsia Thouars| |[Legume Data Portal](/taxonomy/taxon/865920)|    [GBIF](https://www.gbif.org/species/2963210)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22666-1)|  
+| Isoberlinia Craib & Stapf|  |[Legume Data Portal](/taxonomy/taxon/867187)|    [GBIF](https://www.gbif.org/species/8108120)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22670-1)|  
+| Julbernardia Pellegr.|  |[Legume Data Portal](/taxonomy/taxon/331522)|    [GBIF](https://www.gbif.org/species/2981743)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22686-1)| 
+| Lebruniodendron J.Léonard|  |[Legume Data Portal](/taxonomy/taxon/351173)|    [GBIF](https://www.gbif.org/species/2983908)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22753-1)|  
+| Leonardoxa Aubrév.| |[Legume Data Portal](/taxonomy/taxon/345888)|    [GBIF](https://www.gbif.org/species/2947375)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22765-1)|  
+| Leucostegane Prain| |[Legume Data Portal](/taxonomy/taxon/351287)|    [GBIF](https://www.gbif.org/species/2952637)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22790-1)|  
+| Librevillea Hoyle|  |[Legume Data Portal](/taxonomy/taxon/351334)|    [GBIF](https://www.gbif.org/species/2941197)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22793-1)|  
+| Loesenera Harms|  |[Legume Data Portal](/taxonomy/taxon/346457)|    [GBIF](https://www.gbif.org/species/2944255)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22809-1)|  
+| Lysidice Hance| |[Legume Data Portal](/taxonomy/taxon/346717)|    [GBIF](https://www.gbif.org/species/2958145)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22847-1)|  
+| Macrolobium Schreb.|  |[Legume Data Portal](/taxonomy/taxon/366400)|    [GBIF](https://www.gbif.org/species/7743878)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331742-2)| 
+| Michelsonia Hauman| |[Legume Data Portal](/taxonomy/taxon/367964)|    [GBIF](https://www.gbif.org/species/2945463)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22931-1)|  
+| Micklethwaitia G.P.Lewis & Schrire| |[Legume Data Portal](/taxonomy/taxon/376781)|    [GBIF](https://www.gbif.org/species/7301240)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:60435882-2)| 
+| Microberlinia A.Chev.|  |[Legume Data Portal](/taxonomy/taxon/367970)|    [GBIF](https://www.gbif.org/species/2941146)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22934-1)| 
+| Neoapaloxylon Rauschert|  |[Legume Data Portal](/taxonomy/taxon/383941)|    [GBIF](https://www.gbif.org/species/2944228)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:893558-1)| 
+| Neochevalierodendron J.Léonard| |[Legume Data Portal](/taxonomy/taxon/383910)|    [GBIF](https://www.gbif.org/species/2975541)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23009-1)|  
+| Normandiodendron J.Léonard| |[Legume Data Portal](/taxonomy/taxon/383480)|    [GBIF](https://www.gbif.org/species/7302225)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:974656-1)| 
+| Oddoniodendron De Wild.|  |[Legume Data Portal](/taxonomy/taxon/386693)|    [GBIF](https://www.gbif.org/species/2959958)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23058-1)|  
+| Paloue Aubl.| |[Legume Data Portal](/taxonomy/taxon/531743)|    [GBIF](https://www.gbif.org/species/2958895)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30099319-2)| 
+| Paramacrolobium J.Léonard|  |[Legume Data Portal](/taxonomy/taxon/531894)|    [GBIF](https://www.gbif.org/species/2962898)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23144-1)|  
+| Peltogyne Vogel|  |[Legume Data Portal](/taxonomy/taxon/538385)|    [GBIF](https://www.gbif.org/species/2952686)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331837-2)| 
+| Plagiosiphon Harms| |[Legume Data Portal](/taxonomy/taxon/539632)|    [GBIF](https://www.gbif.org/species/2961129)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23267-1)|  
+| Polystemonanthus Harms| |[Legume Data Portal](/taxonomy/taxon/535816)|    [GBIF](https://www.gbif.org/species/2960420)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23320-1)| 
+| Prioria Griseb.|  |[Legume Data Portal](/taxonomy/taxon/536362)|    [GBIF](https://www.gbif.org/species/2947107)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23333-1)|  
+| Saraca L.|  |[Legume Data Portal](/taxonomy/taxon/592102)|    [GBIF](https://www.gbif.org/species/2372883)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23478-1)|  
+| Schotia Jacq.|  |[Legume Data Portal](/taxonomy/taxon/490365)|    [GBIF](https://www.gbif.org/species/2959237)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331941-2)| 
+| Scorodophloeus Harms| |[Legume Data Portal](/taxonomy/taxon/591797)|    [GBIF](https://www.gbif.org/species/2952874)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23511-1)|  
+| Sindora Miq.| |[Legume Data Portal](/taxonomy/taxon/591028)|    [GBIF](https://www.gbif.org/species/2943351)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23561-1)|  
+| Sindoropsis J.Léonard|  |[Legume Data Portal](/taxonomy/taxon/591062)|    [GBIF](https://www.gbif.org/species/2952642)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23562-1)| 
+| Stemonocoleus Harms|  |[Legume Data Portal](/taxonomy/taxon/597087)|    [GBIF](https://www.gbif.org/species/2951341)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23612-1)|  
+| Talbotiella Baker f.| |[Legume Data Portal](/taxonomy/taxon/444684)|    [GBIF](https://www.gbif.org/species/2944645)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23657-1)|  
+| Tamarindus Tourn. ex L.|  |[Legume Data Portal](/taxonomy/taxon/444682)|    [GBIF](https://www.gbif.org/species/2975767)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23658-1)|  
+| Tessmannia Harms| |[Legume Data Portal](/taxonomy/taxon/443659)|    [GBIF](https://www.gbif.org/species/2947679)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23679-1)|  
+| Tetraberlinia (Harms) Hauman| |[Legume Data Portal](/taxonomy/taxon/443642)|    [GBIF](https://www.gbif.org/species/2952737)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23680-1)|  
+| Zenkerella Taub.| |[Legume Data Portal](/taxonomy/taxon/470203)|    [GBIF](https://www.gbif.org/species/2439359)| |[POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23840-1)|  

--- a/taxonomy/papilionoideae.md
+++ b/taxonomy/papilionoideae.md
@@ -113,7 +113,7 @@ Please see the [Species List and Synonyms](/taxonomy/species-list) and [Legume T
 | Arthroclianthus Baill.| [Legume Data Portal](/taxonomy/taxon/653750)| [GBIF](https://www.gbif.org/species/2956517)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21720-1)| 
 | Aspalathus L.| [Legume Data Portal](/taxonomy/taxon/655447)| [GBIF](https://www.gbif.org/species/7826487)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21729-1)| 
 | Astragalus L.| [Legume Data Portal](/taxonomy/taxon/657136)| [GBIF](https://www.gbif.org/species/2933951)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:330028-2)| 
-| Ateleia (Moç & Sessé ex DC.) Benth.| [Legume Data Portal](/taxonomy/taxon/664524)| [GBIF](https://www.gbif.org/species/7690201)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21748-1)| 
+| Ateleia (DC.) Benth.| [Legume Data Portal](/taxonomy/taxon/664524)| [GBIF](https://www.gbif.org/species/7690201)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21748-1)| 
 | Austrodolichos Verdc.| [Legume Data Portal](/taxonomy/taxon/666701)| [GBIF](https://www.gbif.org/species/2946473)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21760-1)| 
 | Austrosteenisia R.Geesink| [Legume Data Portal](/taxonomy/taxon/666719)| [GBIF](https://www.gbif.org/species/2962236)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:924911-1)| 
 | Baphia Afzel. ex G.Lodd.| [Legume Data Portal](/taxonomy/taxon/669303)| [GBIF](https://www.gbif.org/species/2954106)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21775-1)| 
@@ -160,10 +160,10 @@ Please see the [Species List and Synonyms](/taxonomy/species-list) and [Legume T
 | Castanospermum A.Cunn. ex Hook.| [Legume Data Portal](/taxonomy/taxon/704739)| [GBIF](https://www.gbif.org/species/2952128)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:956754-1)| 
 | Centrolobium Mart. ex Benth.| [Legume Data Portal](/taxonomy/taxon/709057)| [GBIF](https://www.gbif.org/species/2945568)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21966-1)|
 | Centrosema (DC.) Benth.| [Legume Data Portal](/taxonomy/taxon/709075)| [GBIF](https://www.gbif.org/species/2964887)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1030212-2)| 
-| Cerradicola L.P. Queiroz| [Legume Data Portal](/taxonomy/taxon/1273060)| [GBIF](https://www.gbif.org/species/10805923)|
+| Cerradicola L.P.Queiroz| [Legume Data Portal](/taxonomy/taxon/1273060)| [GBIF](https://www.gbif.org/species/10805923)|
 | Chadsia Bojer| [Legume Data Portal](/taxonomy/taxon/713915)| [GBIF](https://www.gbif.org/species/2939913)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21976-1)| 
 | Chamaecytisus Link| [Legume Data Portal](/taxonomy/taxon/715322)| [GBIF](https://www.gbif.org/species/8090366)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21983-1)
-| Chapmannia Torr. & A. Gray| [Legume Data Portal](/taxonomy/taxon/715909)| [GBIF](https://www.gbif.org/species/2975655)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21988-1)| 
+| Chapmannia Torr. & A.Gray| [Legume Data Portal](/taxonomy/taxon/715909)| [GBIF](https://www.gbif.org/species/2975655)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:21988-1)| 
 | Chesneya Lindl. ex Endl.| [Legume Data Portal](/taxonomy/taxon/717955)| [GBIF](https://www.gbif.org/species/2956096)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:39812-1)| 
 | Chorizema Labill.| [Legume Data Portal](/taxonomy/taxon/719670)| [GBIF](https://www.gbif.org/species/2968187)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22004-1)| 
 | Christia Moench| [Legume Data Portal](/taxonomy/taxon/719760)| [GBIF](https://www.gbif.org/species/3259727)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22008-1)| 
@@ -249,14 +249,14 @@ Please see the [Species List and Synonyms](/taxonomy/species-list) and [Legume T
 | Erophaca Boiss.| [Legume Data Portal](/taxonomy/taxon/798492)| [GBIF](https://www.gbif.org/species/7961795)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22384-1)| 
 | Errazurizia Phil.| [Legume Data Portal](/taxonomy/taxon/798695)| [GBIF](https://www.gbif.org/species/2967034)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22385-1)| 
 | Erythrina L.| [Legume Data Portal](/taxonomy/taxon/800760)| [GBIF](https://www.gbif.org/species/2945830)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30007957-2)| 
-| Euchilopsis F. Muell.| [Legume Data Portal](/taxonomy/taxon/802592)| [GBIF](https://www.gbif.org/species/2968967)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22396-1)| 
+| Euchilopsis F.Muell.| [Legume Data Portal](/taxonomy/taxon/802592)| [GBIF](https://www.gbif.org/species/2968967)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22396-1)| 
 | Euchlora Eckl. & Zeyh.| [Legume Data Portal](/taxonomy/taxon/802603)| [GBIF](https://www.gbif.org/species/2977700)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22399-1)| 
 | Euchresta Benn.| [Legume Data Portal](/taxonomy/taxon/802608)| [GBIF](https://www.gbif.org/species/2951865)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22400-1)| 
 | Eutaxia R.Br.| [Legume Data Portal](/taxonomy/taxon/805347)| [GBIF](https://www.gbif.org/species/7368925)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22407-1)| 
 | Eversmannia Bunge| [Legume Data Portal](/taxonomy/taxon/805622)| [GBIF](https://www.gbif.org/species/2943923)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22409-1)| 
 | Exostyles Schott| [Legume Data Portal](/taxonomy/taxon/806316)| [GBIF](https://www.gbif.org/species/2944020)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22410-1)| 
 | Eysenhardtia Kunth| [Legume Data Portal](/taxonomy/taxon/806363)| [GBIF](https://www.gbif.org/species/2964730)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:331605-2)| 
-| Ezoloba B.-E. van Wyk & Boatwr.| [Legume Data Portal](/taxonomy/taxon/903858)| [GBIF](https://www.gbif.org/species/6102654)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77110599-1)| 
+| Ezoloba B.-E.van Wyk & Boatwr.| [Legume Data Portal](/taxonomy/taxon/903858)| [GBIF](https://www.gbif.org/species/6102654)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77110599-1)| 
 | Fairchildia Britton & Rose| [Legume Data Portal](/taxonomy/taxon/807570)| [GBIF](https://www.gbif.org/species/2953999)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:295415-2)| 
 | Fiebrigiella Harms| [Legume Data Portal](/taxonomy/taxon/812880)| [GBIF](https://www.gbif.org/species/2952359)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:295427-2)| 
 | Fissicalyx Benth.| [Legume Data Portal](/taxonomy/taxon/813065)| [GBIF](https://www.gbif.org/species/2943739)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22438-1)| 
@@ -287,7 +287,7 @@ Please see the [Species List and Synonyms](/taxonomy/species-list) and [Legume T
 | Harashuteria K.Ohashi & H.Ohashi| [Legume Data Portal](/taxonomy/taxon/1014997)| [GBIF](https://www.gbif.org/species/9705437)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77162647-1)
 | Hardenbergia Benth.| [Legume Data Portal](/taxonomy/taxon/839504)| [GBIF](https://www.gbif.org/species/2948692)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:22556-1)| 
 | Harleyodendron R.S.Cowan| [Legume Data Portal](/taxonomy/taxon/839638)| [GBIF](https://www.gbif.org/species/2950918)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:298542-2)| 
-| Harpalyce Moç. & Sessé ex DC.| [Legume Data Portal](/taxonomy/taxon/839703)| [GBIF](https://www.gbif.org/species/2946917)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:328810-2)| 
+| Harpalyce Moc. & Sessé ex DC.| [Legume Data Portal](/taxonomy/taxon/839703)| [GBIF](https://www.gbif.org/species/2946917)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:328810-2)| 
 | Haymondia A.N.Egan & B.Pan| [Legume Data Portal](/taxonomy/taxon/1002352)| [GBIF](https://www.gbif.org/species/9754698)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77148233-1)| 
 | Hebestigma Urb.| [Legume Data Portal](/taxonomy/taxon/840715)| [GBIF](https://www.gbif.org/species/2966781)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:298163-2)| 
 | Hedysarum L.| [Legume Data Portal](/taxonomy/taxon/840943)| [GBIF](https://www.gbif.org/species/2960767)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30007304-2)| 
@@ -574,4 +574,4 @@ Please see the [Species List and Synonyms](/taxonomy/species-list) and [Legume T
 | Zollernia Wied.-Neuw. & Nees| [Legume Data Portal](/taxonomy/taxon/470083)| [GBIF](https://www.gbif.org/species/2943579)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:23848-1)|
 | Zornia J.F.Gmel.| [Legume Data Portal](/taxonomy/taxon/470142)| [GBIF](https://www.gbif.org/species/2959985)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:30022518-2)| 
 | Zygocarpum Thulin & Lavin| [Legume Data Portal](/taxonomy/taxon/470877)| [GBIF](https://www.gbif.org/species/7301783)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:1020981-1)| 
-| × Laburnocytisus Trel.| [Legume Data Portal](/taxonomy/taxon/350824)| [GBIF](https://www.gbif.org/species/11373245)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77220930-1)|
+| × Laburnocytisus Trel.| [Legume Data Portal](/taxonomy/taxon/350824)| [GBIF](https://www.gbif.org/species/11373245)| [POWO](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:77220930-1)


### PR DESCRIPTION
With updated links (WCVP to POWO) (searched and replaced [WCVP] with [POWO] and wcvp.science.kew.org/taxon/ with powo.science.kew.org/taxon/urn:lsid:ipni.org:names:).